### PR TITLE
Updated to use aws sdk v2

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 * @mongobee @lstolowski
 * @dynomobee @stefanjauker
+* @karhig @karhig

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In this case the migration process will be executed automatically on startup.
 ```java
 @Bean
 public Dynamobee dynamobee(){
-  Dynamobee runner = new Dynamobee(db); //DynamoDB Client: com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+  Dynamobee runner = new Dynamobee(db); //DynamoDB Client: see software.amazon.awssdk.services.dynamodb.DynamoDbClient
   runner.setChangeLogsScanPackage(
        "com.example.yourapp.changelogs"); // the package to be scanned for changesets
   
@@ -49,7 +49,7 @@ public Dynamobee dynamobee(){
 Using dynamobee without a spring context has similar configuration but you have to remember to run `execute()` method to start a migration process.
 
 ```java
-Dynamobee runner = new Dynamobee(db); //DynamoDB Client: see com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+Dynamobee runner = new Dynamobee(db); //DynamoDB Client: see software.amazon.awssdk.services.dynamodb.DynamoDbClient
 runner.setChangeLogsScanPackage(
      "com.example.yourapp.changelogs"); // package to scan for changesets
 
@@ -75,7 +75,7 @@ package com.example.yourapp.changelogs;
 public class DatabaseChangelog {
   
   @ChangeSet(order = "001", id = "someChangeId", author = "testAuthor")
-  public void importantWorkToDo(DB db){
+  public void importantWorkToDo(DynamoDbClient db){
      // task implementation
   }
 
@@ -117,43 +117,9 @@ public void someChange1() {
    // method without arguments can do some non-db changes
 }
 
-@ChangeSet(order = "002", id = "someChangeWithDynamoDB", author = "testAuthor")
-public void someChange2(DynamoDB dynamoDB) {
-  // type: com.amazonaws.services.dynamodbv2.document.DynamoDB
-}
-
-@ChangeSet(order = "003", id = "someChangeWithAmazonDynamoDB", author = "testAuthor")
-public void someChange3(AmazonDynamoDB amazonDynamoDB) {
-  // type: com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-}
-
-@ChangeSet(order = "004", id = "someChangeWithDynamoDBTemplate", author = "testAuthor")
-public void someChange4(DynamoDBTemplate dynamoDBTemplate) {
-  // type: org.socialsignin.spring.data.dynamodb.core.DynamoDBTemplate
-}
-
-@ChangeSet(order = "005", id = "someChangeWithDynamoDBTemplateAndEnvironment", author = "testAuthor")
-public void someChange5(DynamoDBTemplate dynamoDBTemplate, Environment environment) {
-  // type: org.socialsignin.spring.data.dynamodb.core.DynamoDBTemplate
-  // type: org.springframework.core.env.Environment
-}
-
-@ChangeSet(order = "006", id = "someChangeWithDynamoDBTemplateAndAmazonDynamoDB", author = "testAuthor")
-public void someChange6(DynamoDBTemplate dynamoDBTemplate, AmazonDynamoDB amazonDynamoDB) {
-  // type: org.socialsignin.spring.data.dynamodb.core.DynamoDBTemplate
-  // type: com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-}
-
-@ChangeSet(order = "007", id = "someChangeWithDynamoDBTemplateAndAmazonDynamoDB", author = "testAuthor")
-public void someChange7(AmazonDynamoDB amazonDynamoDB, DynamoDBTemplate dynamoDBTemplate) {
-  // type: com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-  // type: org.socialsignin.spring.data.dynamodb.core.DynamoDBTemplate
-}
-
-@ChangeSet(order = "008", id = "someChangeWithAmazonDynamoDBAndEnvironment", author = "testAuthor")
-public void someChange8(AmazonDynamoDB amazonDynamoDB, Environment environment) {
-  // type: com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-  // type: org.springframework.core.env.Environment
+@ChangeSet(order = "002", id = "someChangeWithDynamoDBClient", author = "testAuthor")
+public void someChange2(DynamoDbClient dynamoDB) {
+  // type: software.amazon.awssdk.services.dynamodb.DynamoDbClient
 }
 
 ```
@@ -167,7 +133,7 @@ _Example 1_: annotated change set will be invoked for a `dev` profile
 ```java
 @Profile("dev")
 @ChangeSet(author = "testuser", id = "myDevChangest", order = "01")
-public void devEnvOnly(DB db){
+public void devEnvOnly(DynamoDbClient db){
   // ...
 }
 ```
@@ -177,7 +143,7 @@ _Example 2_: all change sets in a changelog will be invoked for a `test` profile
 @Profile("test")
 public class ChangelogForTestEnv{
   @ChangeSet(author = "testuser", id = "myTestChangest", order = "01")
-  public void testingEnvOnly(DB db){
+  public void testingEnvOnly(DynamoDbClient db){
     // ...
   } 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>com.github.dynamobee</groupId>
 	<artifactId>dynamobee</artifactId>
-	<version>0.7-SNAPSHOT</version>
+	<version>2.0-SNAPSHOT</version>
 
 	<licenses>
 		<license>
@@ -35,6 +35,10 @@
 			<id>stefanjauker</id>
 			<name>stefanjauker</name>
 		</developer>
+    <developer>
+      <id>karhig</id>
+      <name>karhig</name>
+    </developer>
 	</developers>
 
 	<distributionManagement>
@@ -49,17 +53,37 @@
 	</distributionManagement>
 
 	<properties>
+    <java.version>16</java.version>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
+
+    <awssdk.v2.version>2.17.51</awssdk.v2.version>
 		<spring.version>4.0.6.RELEASE</spring.version>
+
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${awssdk.v2.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
 	<dependencies>
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-dynamodb</artifactId>
-			<version>1.11.495</version>
-		</dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>dynamodb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>dynamodb-enhanced</artifactId>
+    </dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-beans</artifactId>
@@ -74,11 +98,6 @@
 			<groupId>org.reflections</groupId>
 			<artifactId>reflections</artifactId>
 			<version>0.9.9</version>
-		</dependency>
-		<dependency>
-			<groupId>com.github.derjust</groupId>
-			<artifactId>spring-data-dynamodb</artifactId>
-			<version>5.1.0</version>
 		</dependency>
 
 		<dependency>
@@ -109,8 +128,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.4</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/com/github/dynamobee/Dynamobee.java
+++ b/src/main/java/com/github/dynamobee/Dynamobee.java
@@ -1,388 +1,271 @@
 package com.github.dynamobee;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
-import com.amazonaws.services.dynamodbv2.document.DynamoDB;
 import com.github.dynamobee.changeset.ChangeEntry;
 import com.github.dynamobee.dao.DynamobeeDao;
+import com.github.dynamobee.utils.ChangeService;
 import com.github.dynamobee.exception.DynamobeeChangeSetException;
 import com.github.dynamobee.exception.DynamobeeConfigurationException;
 import com.github.dynamobee.exception.DynamobeeConnectionException;
 import com.github.dynamobee.exception.DynamobeeException;
-import com.github.dynamobee.utils.ChangeService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.socialsignin.spring.data.dynamodb.core.DynamoDBTemplate;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.core.env.Environment;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.core.env.Environment;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 
 /**
  * Dynamobee runner
  */
 public class Dynamobee implements InitializingBean {
-	private static final Logger logger = LoggerFactory.getLogger(Dynamobee.class);
+  private static final Logger logger = LoggerFactory.getLogger(Dynamobee.class);
 
-	private static final String DEFAULT_CHANGELOG_TABLE_NAME = "dynamobee";
-	private static final boolean DEFAULT_WAIT_FOR_LOCK = false;
-	private static final long DEFAULT_CHANGE_LOG_LOCK_WAIT_TIME = 5L;
-	private static final long DEFAULT_CHANGE_LOG_LOCK_POLL_RATE = 10L;
-	private static final boolean DEFAULT_THROW_EXCEPTION_IF_CANNOT_OBTAIN_LOCK = false;
+  private static final String DEFAULT_CHANGELOG_TABLE_NAME = "dynamobee";
+  private static final boolean DEFAULT_WAIT_FOR_LOCK = false;
+  private static final long DEFAULT_CHANGE_LOG_LOCK_WAIT_TIME = 5L;
+  private static final long DEFAULT_CHANGE_LOG_LOCK_POLL_RATE = 10L;
+  private static final boolean DEFAULT_THROW_EXCEPTION_IF_CANNOT_OBTAIN_LOCK = false;
 
-	private DynamobeeDao dao;
+  private DynamobeeDao dao;
 
-	private boolean enabled = true;
-	private String changeLogsScanPackage;
-	private AmazonDynamoDB amazonDynamoDB;
-	private DynamoDB dynamoDB;
-	private DynamoDBTemplate dynamoDBTemplate;
-	private DynamoDBMapper dynamoDBMapper;
-	private DynamoDBMapperConfig dynamoDBMapperConfig;
-	private Environment springEnvironment;
+  private boolean enabled = true;
+  private String changeLogsScanPackage;
+  private DynamoDbClient dynamoDbClient;
+  private Environment springEnvironment;
 
 
-	/**
-	 * <p>
-	 * Constructor takes com.amazonaws.services.dynamodbv2.AmazonDynamoDB and
-	 * com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig object as a parameter.
-	 * </p>
-	 *
-	 * @param amazonDynamoDB database connection client
-	 * @param dynamoDBMapperConfig dynamodb config used to override table names
-	 * @see AmazonDynamoDB
-	 */
-	public Dynamobee(AmazonDynamoDB amazonDynamoDB, DynamoDBMapperConfig dynamoDBMapperConfig) {
-		this.amazonDynamoDB = amazonDynamoDB;
-		if (dynamoDBMapperConfig != null) {
-			this.dynamoDBMapperConfig = dynamoDBMapperConfig;
-		} else {
-			this.dynamoDBMapperConfig = DynamoDBMapperConfig.DEFAULT;
-		}
-		this.dynamoDBMapper = new DynamoDBMapper(amazonDynamoDB, this.dynamoDBMapperConfig);
-		this.dynamoDBTemplate = new DynamoDBTemplate(amazonDynamoDB, this.dynamoDBMapper, this.dynamoDBMapperConfig);
-		this.dynamoDB = new DynamoDB(amazonDynamoDB);
-		this.dao = new DynamobeeDao(DEFAULT_CHANGELOG_TABLE_NAME, DEFAULT_WAIT_FOR_LOCK,
-				DEFAULT_CHANGE_LOG_LOCK_WAIT_TIME, DEFAULT_CHANGE_LOG_LOCK_POLL_RATE, DEFAULT_THROW_EXCEPTION_IF_CANNOT_OBTAIN_LOCK);
+  /**
+   * <p>
+   * Constructor takes software.amazon.awssdk.services.dynamodb.DynamoDbClient as a parameter.
+   * </p>
+   *
+   * @param dynamoDbClient database connection client
+   */
+  public Dynamobee(DynamoDbClient dynamoDbClient) {
+    this.dynamoDbClient = dynamoDbClient;
 
-		this.setChangelogTableName(DEFAULT_CHANGELOG_TABLE_NAME);
-	}
+    this.dao = new DynamobeeDao(DEFAULT_CHANGELOG_TABLE_NAME, DEFAULT_WAIT_FOR_LOCK,
+        DEFAULT_CHANGE_LOG_LOCK_WAIT_TIME, DEFAULT_CHANGE_LOG_LOCK_POLL_RATE, DEFAULT_THROW_EXCEPTION_IF_CANNOT_OBTAIN_LOCK);
 
-	/**
-	 * <p>
-	 * Constructor takes com.amazonaws.services.dynamodbv2.AmazonDynamoDB object as a parameter.
-	 * </p>
-	 * <p>
-	 * For more details about <tt>DynamoDB</tt> please see com.amazonaws.services.dynamodbv2.AmazonDynamoDB docs
-	 * </p>
-	 *
-	 * @param amazonDynamoDB database connection client
-	 * @see AmazonDynamoDB
-	 */
-	public Dynamobee(AmazonDynamoDB amazonDynamoDB) {
-		this(amazonDynamoDB, null);
-	}
+    this.setChangelogTableName(DEFAULT_CHANGELOG_TABLE_NAME);
+  }
 
-	/**
-	 * For Spring users: executing dynamobee after bean is created in the Spring context
-	 *
-	 * @throws Exception exception
-	 */
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		execute();
-	}
+  /**
+   * For Spring users: executing dynamobee after bean is created in the Spring context
+   *
+   * @throws Exception exception
+   */
+  @Override
+  public void afterPropertiesSet() throws Exception {
+    execute();
+  }
 
-	/**
-	 * Executing migration
-	 *
-	 * @throws DynamobeeException exception
-	 */
-	public void execute() throws DynamobeeException {
-		if (!isEnabled()) {
-			logger.info("Dynamobee is disabled. Exiting.");
-			return;
-		}
+  /**
+   * Executing migration
+   *
+   * @throws DynamobeeException exception
+   */
+  public void execute() throws DynamobeeException {
+    if (!isEnabled()) {
+      logger.info("Dynamobee is disabled. Exiting.");
+      return;
+    }
 
-		validateConfig();
+    validateConfig();
 
-		dao.connectDynamoDB(this.dynamoDB);
+    dao.connectDynamoDB(this.dynamoDbClient);
 
-		if (!dao.acquireProcessLock()) {
-			logger.info("Dynamobee did not acquire process lock. Exiting.");
-			return;
-		}
+    if (!dao.acquireProcessLock()) {
+      logger.info("Dynamobee did not acquire process lock. Exiting.");
+      return;
+    }
 
-		logger.info("Dynamobee acquired process lock, starting the data migration sequence..");
+    logger.info("Dynamobee acquired process lock, starting the data migration sequence..");
 
-		try {
-			executeMigration();
-		} catch (Exception e) {
-			logger.error("Dynamobee migration failed", e);
-			throw e;
-		} finally {
-			logger.info("Dynamobee is releasing process lock.");
-			dao.releaseProcessLock();
-		}
+    try {
+      executeMigration();
+    } catch (Exception e) {
+      logger.error("Dynamobee migration failed", e);
+      throw e;
+    } finally {
+      logger.info("Dynamobee is releasing process lock.");
+      dao.releaseProcessLock();
+    }
 
-		logger.info("Dynamobee has finished his job.");
-	}
+    logger.info("Dynamobee has finished his job.");
+  }
 
-	private void executeMigration() throws DynamobeeConnectionException, DynamobeeException {
+  private void executeMigration() throws DynamobeeException {
 
-		ChangeService service = new ChangeService(changeLogsScanPackage, springEnvironment);
+    ChangeService service = new ChangeService(changeLogsScanPackage, springEnvironment);
 
-		for (Class<?> changelogClass : service.fetchChangeLogs()) {
+    for (Class<?> changelogClass : service.fetchChangeLogs()) {
 
-			Object changelogInstance = null;
-			try {
-				changelogInstance = changelogClass.getConstructor().newInstance();
-				List<Method> changesetMethods = service.fetchChangeSets(changelogInstance.getClass());
+      Object changelogInstance = null;
+      try {
+        changelogInstance = changelogClass.getConstructor().newInstance();
+        List<Method> changesetMethods = service.fetchChangeSets(changelogInstance.getClass());
 
-				for (Method changesetMethod : changesetMethods) {
-					ChangeEntry changeEntry = service.createChangeEntry(changesetMethod);
+        for (Method changesetMethod : changesetMethods) {
+          ChangeEntry changeEntry = service.createChangeEntry(changesetMethod);
 
-					try {
-						if (dao.isNewChange(changeEntry)) {
-							executeChangeSetMethod(changesetMethod, changelogInstance, this.dynamoDB);
-							dao.save(changeEntry);
-							logger.info(changeEntry + " applied");
-						} else if (service.isRunAlwaysChangeSet(changesetMethod)) {
-							executeChangeSetMethod(changesetMethod, changelogInstance, this.dynamoDB);
-							logger.info(changeEntry + " reapplied");
-						} else {
-							logger.info(changeEntry + " passed over");
-						}
-					} catch (DynamobeeChangeSetException e) {
-						logger.error(e.getMessage());
-					}
-				}
-			} catch (NoSuchMethodException e) {
-				throw new DynamobeeException(e.getMessage(), e);
-			} catch (IllegalAccessException e) {
-				throw new DynamobeeException(e.getMessage(), e);
-			} catch (InvocationTargetException e) {
-				Throwable targetException = e.getTargetException();
-				throw new DynamobeeException(targetException.getMessage(), e);
-			} catch (InstantiationException e) {
-				throw new DynamobeeException(e.getMessage(), e);
-			}
+          try {
+            if (dao.isNewChange(changeEntry)) {
+              executeChangeSetMethod(changesetMethod, changelogInstance, this.dynamoDbClient);
+              dao.save(changeEntry);
+              logger.info(changeEntry + " applied");
+            } else if (service.isRunAlwaysChangeSet(changesetMethod)) {
+              executeChangeSetMethod(changesetMethod, changelogInstance, this.dynamoDbClient);
+              logger.info(changeEntry + " reapplied");
+            } else {
+              logger.info(changeEntry + " passed over");
+            }
+          } catch (DynamobeeChangeSetException e) {
+            logger.error(e.getMessage());
+          }
+        }
+      } catch (NoSuchMethodException | IllegalAccessException | InstantiationException e) {
+        throw new DynamobeeException(e.getMessage(), e);
+      } catch (InvocationTargetException e) {
+        Throwable targetException = e.getTargetException();
+        throw new DynamobeeException(targetException.getMessage(), e);
+      }
 
-		}
-	}
+    }
+  }
 
-	private Object executeChangeSetMethod(Method changeSetMethod, Object changeLogInstance, DynamoDB db)
-			throws IllegalAccessException, InvocationTargetException, DynamobeeChangeSetException {
-		if (changeSetMethod.getParameterTypes().length == 1
-				&& changeSetMethod.getParameterTypes()[0].equals(DynamoDB.class)) {
-			logger.debug("method with DynamoDB argument");
+  private void executeChangeSetMethod(Method changeSetMethod, Object changeLogInstance, DynamoDbClient db)
+      throws IllegalAccessException, InvocationTargetException, DynamobeeChangeSetException {
+    if (changeSetMethod.getParameterTypes().length == 1
+        && changeSetMethod.getParameterTypes()[0].equals(DynamoDbClient.class)) {
+      logger.debug("method with DynamoDB argument");
 
-			return changeSetMethod.invoke(changeLogInstance, db);
+      changeSetMethod.invoke(changeLogInstance, db);
 
-		} else if (changeSetMethod.getParameterTypes().length == 1
-				&& changeSetMethod.getParameterTypes()[0].equals(AmazonDynamoDB.class)) {
-			logger.debug("method with AmazonDynamoDB argument");
+    } else if (changeSetMethod.getParameterTypes().length == 0) {
+      logger.debug("method with no params");
 
-			return changeSetMethod.invoke(changeLogInstance, amazonDynamoDB);
+      changeSetMethod.invoke(changeLogInstance);
 
-		} else if (changeSetMethod.getParameterTypes().length == 1
-				&& changeSetMethod.getParameterTypes()[0].equals(DynamoDBTemplate.class)) {
-			logger.debug("method with DynamoDBTemplate argument");
+    } else {
+      throw new DynamobeeChangeSetException("ChangeSet method " + changeSetMethod.getName() +
+          " has wrong arguments list. Please see docs for more info!");
+    }
+  }
 
-			return changeSetMethod.invoke(changeLogInstance,
-					dynamoDBTemplate != null ? dynamoDBTemplate : new DynamoDBTemplate(amazonDynamoDB, this.dynamoDBMapper, this.dynamoDBMapperConfig));
+  private void validateConfig() throws DynamobeeConfigurationException {
+    if (changeLogsScanPackage == null || changeLogsScanPackage.trim().length() == 0) {
+      throw new DynamobeeConfigurationException("Scan package for changelogs is not set: use appropriate setter");
+    }
+  }
 
-		} else if (changeSetMethod.getParameterTypes().length == 2
-				&& changeSetMethod.getParameterTypes()[0].equals(DynamoDBTemplate.class)
-				&& changeSetMethod.getParameterTypes()[1].equals(Environment.class)) {
-			logger.debug("method with DynamoDBTemplate and Environment arguments");
+  /**
+   * @return true if an execution is in progress, in any process.
+   * @throws DynamobeeConnectionException exception
+   */
+  public boolean isExecutionInProgress() throws DynamobeeConnectionException {
+    return dao.isProccessLockHeld();
+  }
 
-			return changeSetMethod.invoke(changeLogInstance,
-					dynamoDBTemplate != null ? dynamoDBTemplate : new DynamoDBTemplate(amazonDynamoDB, this.dynamoDBMapper, this.dynamoDBMapperConfig),
-					springEnvironment);
+  /**
+   * Package name where @ChangeLog-annotated classes are kept.
+   *
+   * @param changeLogsScanPackage package where your changelogs are
+   * @return Dynamobee object for fluent interface
+   */
+  public Dynamobee setChangeLogsScanPackage(String changeLogsScanPackage) {
+    this.changeLogsScanPackage = changeLogsScanPackage;
+    return this;
+  }
 
-		} else if (changeSetMethod.getParameterTypes().length == 2
-				&& changeSetMethod.getParameterTypes()[0].equals(DynamoDBMapper.class)
-				&& changeSetMethod.getParameterTypes()[1].equals(AmazonDynamoDB.class)) {
-			logger.debug("method with DynamoDBMapper and AmazonDynamoDB arguments");
+  /**
+   * @return true if Dynamobee runner is enabled and able to run, otherwise false
+   */
+  public boolean isEnabled() {
+    return enabled;
+  }
 
-			return changeSetMethod.invoke(changeLogInstance, dynamoDBMapper != null ? dynamoDBMapper : new DynamoDBTemplate(amazonDynamoDB, this.dynamoDBMapper, this.dynamoDBMapperConfig),
-					amazonDynamoDB);
+  /**
+   * Feature which enables/disables Dynamobee runner execution
+   *
+   * @param enabled Dynamobee will run only if this option is set to true
+   * @return Dynamobee object for fluent interface
+   */
+  public Dynamobee setEnabled(boolean enabled) {
+    this.enabled = enabled;
+    return this;
+  }
 
-		} else if (changeSetMethod.getParameterTypes().length == 2
-				&& changeSetMethod.getParameterTypes()[0].equals(AmazonDynamoDB.class)
-				&& changeSetMethod.getParameterTypes()[1].equals(DynamoDBMapper.class)) {
+  /**
+   * Feature which enables/disables waiting for lock if it's already obtained
+   *
+   * @param waitForLock Dynamobee will be waiting for lock if it's already obtained if this option is set to true
+   * @return Dynamobee object for fluent interface
+   */
+  public Dynamobee setWaitForLock(boolean waitForLock) {
+    this.dao.setWaitForLock(waitForLock);
+    return this;
+  }
 
-			logger.debug("method with AmazonDynamoDB and DynamoDBMapper arguments");
+  /**
+   * Waiting time for acquiring lock if waitForLock is true
+   *
+   * @param changeLogLockWaitTime Waiting time in minutes for acquiring lock
+   * @return Dynamobee object for fluent interface
+   */
+  public Dynamobee setChangeLogLockWaitTime(long changeLogLockWaitTime) {
+    this.dao.setChangeLogLockWaitTime(changeLogLockWaitTime);
+    return this;
+  }
 
-			return changeSetMethod.invoke(changeLogInstance, amazonDynamoDB,
-					dynamoDBMapper != null ? dynamoDBMapper : new DynamoDBMapper(amazonDynamoDB));
+  /**
+   * Poll rate for acquiring lock if waitForLock is true
+   *
+   * @param changeLogLockPollRate Poll rate in seconds for acquiring lock
+   * @return Dynamobee object for fluent interface
+   */
+  public Dynamobee setChangeLogLockPollRate(long changeLogLockPollRate) {
+    this.dao.setChangeLogLockPollRate(changeLogLockPollRate);
+    return this;
+  }
 
-		} else if (changeSetMethod.getParameterTypes().length == 2
-				&& changeSetMethod.getParameterTypes()[0].equals(DynamoDBTemplate.class)
-				&& changeSetMethod.getParameterTypes()[1].equals(AmazonDynamoDB.class)) {
-			logger.debug("method with DynamoDBTemplate and AmazonDynamoDB arguments");
+  /**
+   * Feature which enables/disables throwing DynamobeeLockException if Dynamobee can not obtain lock
+   *
+   * @param throwExceptionIfCannotObtainLock Dynamobee will throw DynamobeeLockException if lock can not be obtained
+   * @return Dynamobee object for fluent interface
+   */
+  public Dynamobee setThrowExceptionIfCannotObtainLock(boolean throwExceptionIfCannotObtainLock) {
+    this.dao.setThrowExceptionIfCannotObtainLock(throwExceptionIfCannotObtainLock);
+    return this;
+  }
 
-			return changeSetMethod.invoke(changeLogInstance, dynamoDBTemplate != null ? dynamoDBTemplate : new DynamoDBTemplate(amazonDynamoDB, this.dynamoDBMapper, this.dynamoDBMapperConfig),
-					amazonDynamoDB);
+  /**
+   * Set Environment object for Spring Profiles (@Profile) integration
+   *
+   * @param environment org.springframework.core.env.Environment object to inject
+   * @return Dynamobee object for fluent interface
+   */
+  public Dynamobee setSpringEnvironment(Environment environment) {
+    this.springEnvironment = environment;
+    return this;
+  }
 
-		} else if (changeSetMethod.getParameterTypes().length == 2
-				&& changeSetMethod.getParameterTypes()[0].equals(AmazonDynamoDB.class)
-				&& changeSetMethod.getParameterTypes()[1].equals(DynamoDBTemplate.class)) {
-			logger.debug("method with AmazonDynamoDB and DynamoDBTemplate arguments");
-
-			return changeSetMethod.invoke(changeLogInstance, amazonDynamoDB,
-					dynamoDBTemplate != null ? dynamoDBTemplate : new DynamoDBTemplate(amazonDynamoDB, this.dynamoDBMapper, this.dynamoDBMapperConfig));
-
-		} else if (changeSetMethod.getParameterTypes().length == 2
-				&& changeSetMethod.getParameterTypes()[0].equals(AmazonDynamoDB.class)
-				&& changeSetMethod.getParameterTypes()[1].equals(Environment.class)) {
-			logger.debug("method with AmazonDynamoDB and Environment arguments");
-
-			return changeSetMethod.invoke(changeLogInstance, amazonDynamoDB, springEnvironment);
-
-		} else if (changeSetMethod.getParameterTypes().length == 0) {
-			logger.debug("method with no params");
-
-			return changeSetMethod.invoke(changeLogInstance);
-
-		} else {
-			throw new DynamobeeChangeSetException("ChangeSet method " + changeSetMethod.getName() +
-					" has wrong arguments list. Please see docs for more info!");
-		}
-	}
-
-	private void validateConfig() throws DynamobeeConfigurationException {
-		if (changeLogsScanPackage == null || changeLogsScanPackage.trim().length() == 0) {
-			throw new DynamobeeConfigurationException("Scan package for changelogs is not set: use appropriate setter");
-		}
-	}
-
-	/**
-	 * @return true if an execution is in progress, in any process.
-	 * @throws DynamobeeConnectionException exception
-	 */
-	public boolean isExecutionInProgress() throws DynamobeeConnectionException {
-		return dao.isProccessLockHeld();
-	}
-
-	/**
-	 * Package name where @ChangeLog-annotated classes are kept.
-	 *
-	 * @param changeLogsScanPackage package where your changelogs are
-	 * @return Dynamobee object for fluent interface
-	 */
-	public Dynamobee setChangeLogsScanPackage(String changeLogsScanPackage) {
-		this.changeLogsScanPackage = changeLogsScanPackage;
-		return this;
-	}
-
-	/**
-	 * @return true if Dynamobee runner is enabled and able to run, otherwise false
-	 */
-	public boolean isEnabled() {
-		return enabled;
-	}
-
-	/**
-	 * Feature which enables/disables Dynamobee runner execution
-	 *
-	 * @param enabled Dynamobee will run only if this option is set to true
-	 * @return Dynamobee object for fluent interface
-	 */
-	public Dynamobee setEnabled(boolean enabled) {
-		this.enabled = enabled;
-		return this;
-	}
-
-	/**
-	 * Feature which enables/disables waiting for lock if it's already obtained
-	 *
-	 * @param waitForLock Dynamobee will be waiting for lock if it's already obtained if this option is set to true
-	 * @return Dynamobee object for fluent interface
-	 */
-	public Dynamobee setWaitForLock(boolean waitForLock) {
-		this.dao.setWaitForLock(waitForLock);
-		return this;
-	}
-
-	/**
-	 * Waiting time for acquiring lock if waitForLock is true
-	 *
-	 * @param changeLogLockWaitTime Waiting time in minutes for acquiring lock
-	 * @return Dynamobee object for fluent interface
-	 */
-	public Dynamobee setChangeLogLockWaitTime(long changeLogLockWaitTime) {
-		this.dao.setChangeLogLockWaitTime(changeLogLockWaitTime);
-		return this;
-	}
-
-	/**
-	 * Poll rate for acquiring lock if waitForLock is true
-	 *
-	 * @param changeLogLockPollRate Poll rate in seconds for acquiring lock
-	 * @return Dynamobee object for fluent interface
-	 */
-	public Dynamobee setChangeLogLockPollRate(long changeLogLockPollRate) {
-		this.dao.setChangeLogLockPollRate(changeLogLockPollRate);
-		return this;
-	}
-
-	/**
-	 * Feature which enables/disables throwing DynamobeeLockException if Dynamobee can not obtain lock
-	 *
-	 * @param throwExceptionIfCannotObtainLock Dynamobee will throw DynamobeeLockException if lock can not be obtained
-	 * @return Dynamobee object for fluent interface
-	 */
-	public Dynamobee setThrowExceptionIfCannotObtainLock(boolean throwExceptionIfCannotObtainLock) {
-		this.dao.setThrowExceptionIfCannotObtainLock(throwExceptionIfCannotObtainLock);
-		return this;
-	}
-
-	/**
-	 * Set Environment object for Spring Profiles (@Profile) integration
-	 *
-	 * @param environment org.springframework.core.env.Environment object to inject
-	 * @return Dynamobee object for fluent interface
-	 */
-	public Dynamobee setSpringEnvironment(Environment environment) {
-		this.springEnvironment = environment;
-		return this;
-	}
-
-	/**
-	 * Sets pre-configured {@link DynamoDBTemplate} instance to use by the Dynamobee
-	 *
-	 * @param dynamoDBTemplate instance of the {@link DynamoDBTemplate}
-	 * @return Dynamobee object for fluent interface
-	 */
-	public Dynamobee setDynamoDBTemplate(DynamoDBTemplate dynamoDBTemplate) {
-		this.dynamoDBTemplate = dynamoDBTemplate;
-		return this;
-	}
-
-	/**
-	 * Overwrites a default dynamobee changelog collection hardcoded in DEFAULT_CHANGELOG_TABLE_NAME.
-	 *
-	 * CAUTION! Use this method carefully - when changing the name on a existing system,
-	 * your changelogs will be executed again on your DynamoDB instance
-	 *
-	 * @param changelogTableName a new changelog collection name
-	 * @return Dynamobee object for fluent interface
-	 */
-	public Dynamobee setChangelogTableName(String changelogTableName) {
-
-		if (dynamoDBMapperConfig != null && dynamoDBMapperConfig.getTableNameOverride() != null
-				&& dynamoDBMapperConfig.getTableNameOverride().getTableNamePrefix() != null) {
-			changelogTableName = dynamoDBMapperConfig.getTableNameOverride().getTableNamePrefix() + changelogTableName;
-		}
-
-		this.dao.setChangelogTableName(changelogTableName);
-
-		return this;
-	}
+  /**
+   * Overwrites a default dynamobee changelog collection hardcoded in DEFAULT_CHANGELOG_TABLE_NAME.
+   * <p>
+   * CAUTION! Use this method carefully - when changing the name on a existing system,
+   * your changelogs will be executed again on your DynamoDB instance
+   *
+   * @param changelogTableName a new changelog collection name
+   * @return Dynamobee object for fluent interface
+   */
+  public Dynamobee setChangelogTableName(String changelogTableName) {
+    this.dao.setChangelogTableName(changelogTableName);
+    return this;
+  }
 }

--- a/src/main/java/com/github/dynamobee/changeset/ChangeEntry.java
+++ b/src/main/java/com/github/dynamobee/changeset/ChangeEntry.java
@@ -1,78 +1,116 @@
 package com.github.dynamobee.changeset;
 
+import com.github.dynamobee.Dynamobee;
+import com.github.dynamobee.utils.DynamoDbEnhancedTableSchemaUtils;
 import java.util.Date;
-
-import com.amazonaws.services.dynamodbv2.document.Item;
-import com.amazonaws.services.dynamodbv2.document.spec.QuerySpec;
+import software.amazon.awssdk.enhanced.dynamodb.DefaultAttributeConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbImmutable;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 
 
 /**
- * Entry in the changes collection log {@link com.github.dynamobee.Dynamobee#DEFAULT_CHANGELOG_TABLE_NAME}
+ * Entry in the changes collection log {@link Dynamobee#DEFAULT_CHANGELOG_TABLE_NAME}
  * Type: entity class.
  */
+@DynamoDbImmutable(
+    builder = ChangeEntry.Builder.class,
+    converterProviders = {
+    DynamoDbEnhancedTableSchemaUtils.DynamoBeeConverterProvider.class,
+    DefaultAttributeConverterProvider.class})
 public class ChangeEntry {
-	public static final String KEY_CHANGEID = "changeId";
-	public static final String KEY_AUTHOR = "author";
-	public static final String KEY_TIMESTAMP = "timestamp";
-	public static final String KEY_CHANGELOGCLASS = "changeLogClass";
-	public static final String KEY_CHANGESETMETHOD = "changeSetMethod";
+  private final String changeId;
+  private final String author;
+  private final Date timestamp;
+  private final String changeLogClass;
+  private final String changeSetMethodName;
 
-	private String changeId;
-	private String author;
-	private Date timestamp;
-	private String changeLogClass;
-	private String changeSetMethodName;
+  private ChangeEntry(Builder b) {
+    this.changeId = b.changeId;
+    this.author = b.author;
+    this.timestamp = b.timestamp;
+    this.changeLogClass = b.changeLogClass;
+    this.changeSetMethodName = b.changeSetMethodName;
+  }
 
-	public ChangeEntry(String changeId, String author, Date timestamp, String changeLogClass, String changeSetMethodName) {
-		this.changeId = changeId;
-		this.author = author;
-		this.timestamp = new Date(timestamp.getTime());
-		this.changeLogClass = changeLogClass;
-		this.changeSetMethodName = changeSetMethodName;
-	}
+  public static Builder builder() {
+    return new Builder();
+  }
 
-	public Item buildFullDBObject() {
-		return new Item()
-				.withPrimaryKey(KEY_CHANGEID, this.changeId)
-				.with(KEY_AUTHOR, this.author)
-				.with(KEY_TIMESTAMP, this.timestamp.getTime())
-				.with(KEY_CHANGELOGCLASS, this.changeLogClass)
-				.with(KEY_CHANGESETMETHOD, this.changeSetMethodName);
-	}
+  @Override
+  public String toString() {
+    return "[ChangeSet: id=" + this.changeId +
+        ", author=" + this.author +
+        ", timestamp=" + this.timestamp +
+        ", changeLogClass=" + this.changeLogClass +
+        ", changeSetMethod=" + this.changeSetMethodName + "]";
+  }
 
-	public QuerySpec buildSearchQuerySpec() {
-//		return new Document()
-//				.append(KEY_CHANGEID, this.changeId)
-//				.append(KEY_AUTHOR, this.author);
-		return new QuerySpec().withKeyConditionExpression(KEY_CHANGEID + " = " + this.changeId);
-	}
+  @DynamoDbPartitionKey
+  @DynamoDbAttribute("changeId")
+  public String getChangeId() {
+    return this.changeId;
+  }
 
-	@Override
-	public String toString() {
-		return "[ChangeSet: id=" + this.changeId +
-				", author=" + this.author +
-				", changeLogClass=" + this.changeLogClass +
-				", changeSetMethod=" + this.changeSetMethodName + "]";
-	}
+  @DynamoDbAttribute("author")
+  public String getAuthor() {
+    return this.author;
+  }
 
-	public String getChangeId() {
-		return this.changeId;
-	}
+  @DynamoDbAttribute("timestamp")
+  public Date getTimestamp() {
+    return this.timestamp;
+  }
 
-	public String getAuthor() {
-		return this.author;
-	}
+  @DynamoDbAttribute("changeLogClass")
+  public String getChangeLogClass() {
+    return this.changeLogClass;
+  }
 
-	public Date getTimestamp() {
-		return this.timestamp;
-	}
+  @DynamoDbAttribute("changeSetMethod")
+  public String getChangeSetMethodName() {
+    return this.changeSetMethodName;
+  }
 
-	public String getChangeLogClass() {
-		return this.changeLogClass;
-	}
+  public static final class Builder {
+    private String changeId;
+    private String author;
+    private Date timestamp;
+    private String changeLogClass;
+    private String changeSetMethodName;
 
-	public String getChangeSetMethodName() {
-		return this.changeSetMethodName;
-	}
+    private Builder() {
+      // Only created via ChangeEntry.builder()
+    }
+
+    public Builder setChangeId(String changeId) {
+      this.changeId = changeId;
+      return this;
+    }
+
+    public Builder setAuthor(String author) {
+      this.author = author;
+      return this;
+    }
+
+    public Builder setTimestamp(Date timestamp) {
+      this.timestamp = timestamp;
+      return this;
+    }
+
+    public Builder setChangeLogClass(String changeLogClass) {
+      this.changeLogClass = changeLogClass;
+      return this;
+    }
+
+    public Builder setChangeSetMethodName(String changeSetMethodName) {
+      this.changeSetMethodName = changeSetMethodName;
+      return this;
+    }
+
+    public ChangeEntry build() {
+      return new ChangeEntry(this);
+    }
+  }
 
 }

--- a/src/main/java/com/github/dynamobee/utils/ChangeLogComparator.java
+++ b/src/main/java/com/github/dynamobee/utils/ChangeLogComparator.java
@@ -2,10 +2,9 @@ package com.github.dynamobee.utils;
 
 import static org.springframework.util.StringUtils.hasText;
 
+import com.github.dynamobee.changeset.ChangeLog;
 import java.io.Serializable;
 import java.util.Comparator;
-
-import com.github.dynamobee.changeset.ChangeLog;
 
 
 /**

--- a/src/main/java/com/github/dynamobee/utils/ChangeService.java
+++ b/src/main/java/com/github/dynamobee/utils/ChangeService.java
@@ -2,6 +2,10 @@ package com.github.dynamobee.utils;
 
 import static java.util.Arrays.asList;
 
+import com.github.dynamobee.changeset.ChangeEntry;
+import com.github.dynamobee.changeset.ChangeLog;
+import com.github.dynamobee.changeset.ChangeSet;
+import com.github.dynamobee.exception.DynamobeeChangeSetException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
@@ -14,155 +18,151 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.reflections.Reflections;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
-
-import com.github.dynamobee.changeset.ChangeEntry;
-import com.github.dynamobee.changeset.ChangeLog;
-import com.github.dynamobee.changeset.ChangeSet;
-import com.github.dynamobee.exception.DynamobeeChangeSetException;
 
 
 /**
  * Utilities to deal with reflections and annotations
  */
 public class ChangeService {
-	private static final String DEFAULT_PROFILE = "default";
+  private static final String DEFAULT_PROFILE = "default";
 
-	private final String changeLogsBasePackage;
-	private final List<String> activeProfiles;
+  private final String changeLogsBasePackage;
+  private final List<String> activeProfiles;
 
-	public ChangeService(String changeLogsBasePackage) {
-		this(changeLogsBasePackage, null);
-	}
+  public ChangeService(String changeLogsBasePackage) {
+    this(changeLogsBasePackage, null);
+  }
 
-	public ChangeService(String changeLogsBasePackage, Environment environment) {
-		this.changeLogsBasePackage = changeLogsBasePackage;
+  public ChangeService(String changeLogsBasePackage, Environment environment) {
+    this.changeLogsBasePackage = changeLogsBasePackage;
 
-		if (environment != null && environment.getActiveProfiles() != null && environment.getActiveProfiles().length > 0) {
-			this.activeProfiles = asList(environment.getActiveProfiles());
-		} else {
-			this.activeProfiles = asList(DEFAULT_PROFILE);
-		}
-	}
+    if (environment != null && environment.getActiveProfiles() != null && environment.getActiveProfiles().length > 0) {
+      this.activeProfiles = asList(environment.getActiveProfiles());
+    } else {
+      this.activeProfiles = asList(DEFAULT_PROFILE);
+    }
+  }
 
-	public List<Class<?>> fetchChangeLogs() {
-		Reflections reflections = new Reflections(changeLogsBasePackage);
-		Set<Class<?>> changeLogs = reflections.getTypesAnnotatedWith(ChangeLog.class); // TODO remove dependency, do own method
-		List<Class<?>> filteredChangeLogs = (List<Class<?>>) filterByActiveProfiles(changeLogs);
+  public List<Class<?>> fetchChangeLogs() {
+    Reflections reflections = new Reflections(changeLogsBasePackage);
+    Set<Class<?>> changeLogs = reflections.getTypesAnnotatedWith(ChangeLog.class); // TODO remove dependency, do own method
+    List<Class<?>> filteredChangeLogs = (List<Class<?>>) filterByActiveProfiles(changeLogs);
 
-		Collections.sort(filteredChangeLogs, new ChangeLogComparator());
+    Collections.sort(filteredChangeLogs, new ChangeLogComparator());
 
-		return filteredChangeLogs;
-	}
+    return filteredChangeLogs;
+  }
 
-	public List<Method> fetchChangeSets(final Class<?> type) throws DynamobeeChangeSetException {
-		final List<Method> changeSets = filterChangeSetAnnotation(asList(type.getDeclaredMethods()));
-		final List<Method> filteredChangeSets = (List<Method>) filterByActiveProfiles(changeSets);
+  public List<Method> fetchChangeSets(final Class<?> type) throws DynamobeeChangeSetException {
+    final List<Method> changeSets = filterChangeSetAnnotation(asList(type.getDeclaredMethods()));
+    final List<Method> filteredChangeSets = (List<Method>) filterByActiveProfiles(changeSets);
 
-		Collections.sort(filteredChangeSets, new ChangeSetComparator());
+    Collections.sort(filteredChangeSets, new ChangeSetComparator());
 
-		return filteredChangeSets;
-	}
+    return filteredChangeSets;
+  }
 
-	public boolean isRunAlwaysChangeSet(Method changesetMethod) {
-		if (changesetMethod.isAnnotationPresent(ChangeSet.class)) {
-			ChangeSet annotation = changesetMethod.getAnnotation(ChangeSet.class);
-			return annotation.runAlways();
-		} else {
-			return false;
-		}
-	}
+  public boolean isRunAlwaysChangeSet(Method changesetMethod) {
+    if (changesetMethod.isAnnotationPresent(ChangeSet.class)) {
+      ChangeSet annotation = changesetMethod.getAnnotation(ChangeSet.class);
+      return annotation.runAlways();
+    } else {
+      return false;
+    }
+  }
 
-	public ChangeEntry createChangeEntry(Method changesetMethod) {
-		if (changesetMethod.isAnnotationPresent(ChangeSet.class)) {
-			ChangeSet annotation = changesetMethod.getAnnotation(ChangeSet.class);
+  public ChangeEntry createChangeEntry(Method changesetMethod) {
+    if (changesetMethod.isAnnotationPresent(ChangeSet.class)) {
+      ChangeSet annotation = changesetMethod.getAnnotation(ChangeSet.class);
 
-			return new ChangeEntry(
-					annotation.id(),
-					annotation.author(),
-					new Date(),
-					changesetMethod.getDeclaringClass().getName(),
-					changesetMethod.getName());
-		} else {
-			return null;
-		}
-	}
+      return ChangeEntry.builder()
+          .setChangeId(annotation.id())
+          .setAuthor(annotation.author())
+          .setTimestamp(new Date())
+          .setChangeLogClass(changesetMethod.getDeclaringClass().getName())
+          .setChangeSetMethodName(changesetMethod.getName())
+          .build();
+    } else {
+      return null;
+    }
+  }
 
-	private boolean matchesActiveSpringProfile(AnnotatedElement element) {
-		if (!ClassUtils.isPresent("org.springframework.context.annotation.Profile", null)) {
-			return true;
-		}
+  private boolean matchesActiveSpringProfile(AnnotatedElement element) {
+    if (!ClassUtils.isPresent("org.springframework.context.annotation.Profile", null)) {
+      return true;
+    }
 
-		List<String> profiles = profileAnnotations(element).stream().
+    List<String> profiles = profileAnnotations(element).stream().
         map(Profile::value).
         flatMap(Stream::of).
         collect(Collectors.toList());
-		
-		if (profiles.isEmpty()) {
-		  return true; // no-profiled changeset always matches
+
+    if (profiles.isEmpty()) {
+      return true; // no-profiled changeset always matches
     }
 
-		for (String profile : profiles) {
-			if (profile != null && profile.length() > 0 && profile.charAt(0) == '!') {
-				if (!activeProfiles.contains(profile.substring(1))) {
-					return true;
-				}
-			} else if (activeProfiles.contains(profile)) {
-				return true;
-			}
-		}
-		return false;
-	}
+    for (String profile : profiles) {
+      if (profile != null && profile.length() > 0 && profile.charAt(0) == '!') {
+        if (!activeProfiles.contains(profile.substring(1))) {
+          return true;
+        }
+      } else if (activeProfiles.contains(profile)) {
+        return true;
+      }
+    }
+    return false;
+  }
 
-	private List<?> filterByActiveProfiles(Collection<? extends AnnotatedElement> annotated) {
-		List<AnnotatedElement> filtered = new ArrayList<>();
-		for (AnnotatedElement element : annotated) {
-			if (matchesActiveSpringProfile(element)) {
-				filtered.add(element);
-			}
-		}
-		return filtered;
-	}
+  private List<?> filterByActiveProfiles(Collection<? extends AnnotatedElement> annotated) {
+    List<AnnotatedElement> filtered = new ArrayList<>();
+    for (AnnotatedElement element : annotated) {
+      if (matchesActiveSpringProfile(element)) {
+        filtered.add(element);
+      }
+    }
+    return filtered;
+  }
 
-	private List<Method> filterChangeSetAnnotation(List<Method> allMethods) throws DynamobeeChangeSetException {
-		final Set<String> changeSetIds = new HashSet<>();
-		final List<Method> changesetMethods = new ArrayList<>();
-		for (final Method method : allMethods) {
-			if (method.isAnnotationPresent(ChangeSet.class)) {
-				String id = method.getAnnotation(ChangeSet.class).id();
-				if (changeSetIds.contains(id)) {
-					throw new DynamobeeChangeSetException(String.format("Duplicated changeset id found: '%s'", id));
-				}
-				changeSetIds.add(id);
-				changesetMethods.add(method);
-			}
-		}
-		return changesetMethods;
-	}
+  private List<Method> filterChangeSetAnnotation(List<Method> allMethods) throws DynamobeeChangeSetException {
+    final Set<String> changeSetIds = new HashSet<>();
+    final List<Method> changesetMethods = new ArrayList<>();
+    for (final Method method : allMethods) {
+      if (method.isAnnotationPresent(ChangeSet.class)) {
+        String id = method.getAnnotation(ChangeSet.class).id();
+        if (changeSetIds.contains(id)) {
+          throw new DynamobeeChangeSetException(String.format("Duplicated changeset id found: '%s'", id));
+        }
+        changeSetIds.add(id);
+        changesetMethods.add(method);
+      }
+    }
+    return changesetMethods;
+  }
 
-	private List <Profile> profileAnnotations(AnnotatedElement element) {
-	  return Stream.of(element.getAnnotations()).
+  private List<Profile> profileAnnotations(AnnotatedElement element) {
+    return Stream.of(element.getAnnotations()).
         map(this::getProfile).
         filter((p) -> p != null).
         collect(Collectors.toList());
   }
 
   private Profile getProfile(Annotation annotation) {
-	  if (isProfileAnnotation(annotation)) {
+    if (isProfileAnnotation(annotation)) {
       return (Profile) (annotation);
     } else {
-	    return Stream.of(annotation.annotationType().getAnnotations()).
+      return Stream.of(annotation.annotationType().getAnnotations()).
           filter(this::isProfileAnnotation). //  Does only allow one level of meta-annotation
-          map(this::getProfile).
+              map(this::getProfile).
           filter(p -> p != null).
           findFirst().
           orElse(null);
     }
   }
+
   private boolean isProfileAnnotation(Annotation annotation) {
-	  return annotation.annotationType().equals(Profile.class);
+    return annotation.annotationType().equals(Profile.class);
   }
 }

--- a/src/main/java/com/github/dynamobee/utils/ChangeSetComparator.java
+++ b/src/main/java/com/github/dynamobee/utils/ChangeSetComparator.java
@@ -1,10 +1,9 @@
 package com.github.dynamobee.utils;
 
+import com.github.dynamobee.changeset.ChangeSet;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.Comparator;
-
-import com.github.dynamobee.changeset.ChangeSet;
 
 
 /**

--- a/src/main/java/com/github/dynamobee/utils/DynamoDbEnhancedTableSchemaUtils.java
+++ b/src/main/java/com/github/dynamobee/utils/DynamoDbEnhancedTableSchemaUtils.java
@@ -46,12 +46,12 @@ public class DynamoDbEnhancedTableSchemaUtils {
 
       @Override
       public AttributeValue transformFrom(Date input) {
-        return AttributeValue.builder().s(Long.toString(input.getTime())).build();
+        return AttributeValue.builder().n(Long.toString(input.getTime())).build();
       }
 
       @Override
       public Date transformTo(AttributeValue input) {
-        return new Date(Long.parseLong(input.s()));
+        return new Date(Long.parseLong(input.n()));
       }
 
       @Override
@@ -61,7 +61,7 @@ public class DynamoDbEnhancedTableSchemaUtils {
 
       @Override
       public AttributeValueType attributeValueType() {
-        return AttributeValueType.S;
+        return AttributeValueType.N;
       }
     }
   }

--- a/src/main/java/com/github/dynamobee/utils/DynamoDbEnhancedTableSchemaUtils.java
+++ b/src/main/java/com/github/dynamobee/utils/DynamoDbEnhancedTableSchemaUtils.java
@@ -1,0 +1,69 @@
+package com.github.dynamobee.utils;
+
+import java.util.Date;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class DynamoDbEnhancedTableSchemaUtils {
+
+  private DynamoDbEnhancedTableSchemaUtils() {
+  }
+
+  public static Expression notExists(TableSchema<?> schema) {
+    var builder = Expression.builder();
+    var partitionKeyExpressionName = "#partition_key";
+    builder.putExpressionName(partitionKeyExpressionName, schema.tableMetadata().primaryPartitionKey());
+    schema.tableMetadata().primarySortKey().ifPresentOrElse(
+        sortKey -> {
+          var sortKeyExpressionName = "#sort_key";
+          builder.putExpressionName(sortKeyExpressionName, sortKey);
+          builder.expression("attribute_not_exists(#partition_key) AND attribute_not_exists(#sort_key)");
+        },
+        () -> builder.expression("attribute_not_exists(#partition_key)"));
+    return builder
+        .build();
+  }
+
+  public static final class DynamoBeeConverterProvider implements AttributeConverterProvider {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> AttributeConverter<T> converterFor(
+        EnhancedType<T> enhancedType) {
+      if (enhancedType.rawClass().isAssignableFrom(Date.class)) {
+        return (AttributeConverter<T>) new DateConverter();
+      } else {
+        return null;
+      }
+    }
+
+    public static final class DateConverter implements AttributeConverter<Date> {
+
+      @Override
+      public AttributeValue transformFrom(Date input) {
+        return AttributeValue.builder().s(Long.toString(input.getTime())).build();
+      }
+
+      @Override
+      public Date transformTo(AttributeValue input) {
+        return new Date(Long.parseLong(input.s()));
+      }
+
+      @Override
+      public EnhancedType<Date> type() {
+        return EnhancedType.of(Date.class);
+      }
+
+      @Override
+      public AttributeValueType attributeValueType() {
+        return AttributeValueType.S;
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
I use dynamobee at work for several projects which use the aws v2 sdk. It would be convenient for to have a version of dynamobee which uses the v2 sdk.

I've created this PR to capture the work I've done to port it to the v2 sdk, but I don't know if replacing the v1 sdk entirely in head as a 2.0.0 version is something which is desirable for all use cases, if it would be wiser to create a dynamobee 2.0 fork and have both versions running concurrently, or something else entirely?